### PR TITLE
AB#1110 - change compile to implementation to support latest java sdk

### DIFF
--- a/src/android/barcodescanner.gradle
+++ b/src/android/barcodescanner.gradle
@@ -6,7 +6,7 @@ repositories{
 }
 
 dependencies {
-    compile(name:'barcodescanner-release-2.1.5', ext:'aar')
+    implementation(name:'barcodescanner-release-2.1.5', ext:'aar')
 }
 
 android {


### PR DESCRIPTION
AB#1110

This update is so that this plugin can be used with Capacitor v5. The `compile` directive that was used previously in the dependencies section of the gradle file has been changed to `implementation`.